### PR TITLE
BEVFusion Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,18 @@ To run the container:
 docker run -it --gpus all --name mmdet3d_container mmdet3d-bevfusion bash
 ```
 
-Verify BEVFusion is correctly compiled:
+Verify BEVFusion by running the demo code on demo nuscenes data sample:
 ```
-bash tools/dist_train.sh projects/BEVFusion/configs/bevfusion_lidar_voxel0075_second_secfpn_8xb4-cyclic-20e_nus-3d.py 1
+mkdir -p checkpoints
+wget https://download.openmmlab.com/mmdetection3d/v1.1.0_models/bevfusion/bevfusion_lidar-cam_voxel0075_second_secfpn_8xb4-cyclic-20e_nus-3d-5239b1af.pth \
+     -O checkpoints/bevfusion_lidar-cam_voxel0075_second_secfpn_8xb4-cyclic-20e_nus-3d-5239b1af.pth
+
+python projects/BEVFusion/demo/multi_modality_demo.py \
+    demo/data/nuscenes/n015-2018-07-24-11-22-45+0800__LIDAR_TOP__1532402927647951.pcd.bin \
+    demo/data/nuscenes/ \
+    demo/data/nuscenes/n015-2018-07-24-11-22-45+0800.pkl \
+    projects/BEVFusion/configs/bevfusion_lidar-cam_voxel0075_second_secfpn_8xb4-cyclic-20e_nus-3d.py \
+    checkpoints/bevfusion_lidar-cam_voxel0075_second_secfpn_8xb4-cyclic-20e_nus-3d-5239b1af.pth \
+    --cam-type all
+
 ```

--- a/README.md
+++ b/README.md
@@ -28,3 +28,21 @@ python demo/pcd_demo.py demo/data/kitti/000008.bin pointpillars_hv_secfpn_8xb6-1
 ```
 mim download mmdet3d --config pointpillars_hv_secfpn_8xb6-160e_kitti-3d-car --dest .
 And check outputs/preds/000008.json
+
+
+## MMDetection3D with BEVFusion Extension and compilation
+
+To build an MMdetection3D image with BEVFusion support:
+```
+docker build -t mmdet3d-bevfusion --file mmdet_bevfusion.Dockerfile .
+```
+
+To run the container:
+```
+docker run -it --gpus all --name mmdet3d_container mmdet3d-bevfusion bash
+```
+
+verify BEVFusion is correctly compiled:
+```
+bash tools/dist_train.sh projects/BEVFusion/configs/bevfusion_lidar_voxel0075_second_secfpn_8xb4-cyclic-20e_nus-3d.py 1
+```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Similar to carla official docker prerequisites
 
 Build the image:
 ```
-docker build -t cisl/mmdet --file mmdet.Dockerfile .
+docker build -t cisl/mmdet -f mmdet.Dockerfile .
 ```
 
 To test, run
@@ -34,7 +34,7 @@ And check outputs/preds/000008.json
 
 To build an MMdetection3D image with BEVFusion support:
 ```
-docker build -t mmdet3d-bevfusion --file mmdet_bevfusion.Dockerfile .
+docker build -t mmdet3d-bevfusion -f mmdet_bevfusion.Dockerfile .
 ```
 
 To run the container:
@@ -42,7 +42,7 @@ To run the container:
 docker run -it --gpus all --name mmdet3d_container mmdet3d-bevfusion bash
 ```
 
-verify BEVFusion is correctly compiled:
+Verify BEVFusion is correctly compiled:
 ```
 bash tools/dist_train.sh projects/BEVFusion/configs/bevfusion_lidar_voxel0075_second_secfpn_8xb4-cyclic-20e_nus-3d.py 1
 ```

--- a/mmdet_bevfusion.Dockerfile
+++ b/mmdet_bevfusion.Dockerfile
@@ -1,9 +1,57 @@
-FROM cisl/mmdet
+ARG PYTORCH="2.1.1"
+ARG CUDA="12.1"
+ARG CUDNN="8"
 
-RUN wget https://download.openmmlab.com/mmdetection3d/v1.1.0_models/bevfusion/bevfusion_lidar-cam_voxel0075_second_secfpn_8xb4-cyclic-20e_nus-3d-5239b1af.pth
-RUN wget https://download.openmmlab.com/mmdetection3d/v1.1.0_models/bevfusion/bevfusion_lidar_voxel0075_second_secfpn_8xb4-cyclic-20e_nus-3d-2628f933.pth
+FROM pytorch/pytorch:${PYTORCH}-cuda${CUDA}-cudnn${CUDNN}-devel
 
-# Need to run the following outside dockerfile, inside the instance,
-# sudo `which python` projects/BEVFusion/setup.py develop
-# Running from the dockerfile would incur error: fatal error: cuda_runtime_api.h:
-# Maybe a privilege/path issue TBD
+
+ENV TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6;8.9+PTX;9.0" \
+    TORCH_NVCC_FLAGS="-Xfatbin -compress-all" \
+    CMAKE_PREFIX_PATH="$(dirname $(which conda))/../" \
+    FORCE_CUDA="1"
+
+# Avoid Public GPG key error
+RUN rm -f /etc/apt/sources.list.d/cuda.list \
+    /etc/apt/sources.list.d/nvidia-ml.list && \
+    apt-key del 7fa2af80 || true && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
+
+# Install system dependencies
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    git wget ffmpeg libsm6 libxext6 libxrender-dev libglib2.0-0 ninja-build \
+    --no-install-recommends && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install Python packages required for mmdet3d
+RUN pip install --no-cache-dir \
+    "numpy<2.0" \
+    matplotlib \
+    opencv-python
+
+# Install OpenMMLab core libraries
+RUN pip install --no-cache-dir mmcv==2.1.0 -f https://download.openmmlab.com/mmcv/dist/cu121/torch2.1/index.html && \
+    pip install --no-cache-dir \
+    mmengine>=0.7.1 \
+    mmdet>=3.0.0 \
+    mmdet3d==1.4.0
+
+# Clone and install MMDetection3D, then setup BEVFusion if present
+RUN git clone https://github.com/open-mmlab/mmdetection3d.git -b dev-1.x /mmdetection3d && \
+    pip install --no-cache-dir -e /mmdetection3d 
+    
+
+# Setup BEVFusion
+RUN cd /mmdetection3d && \
+    if [ -f projects/BEVFusion/setup.py ]; then \
+        python3 projects/BEVFusion/setup.py develop; \
+    else \
+        echo "BEVFusion setup.py not found"; \
+    fi
+
+
+# Set working directory
+ENV PYTHONPATH=/mmdetection3d
+WORKDIR /mmdetection3d
+


### PR DESCRIPTION
Add a docker file for building mmdet3d docker with BEVFusion supported.
In the docker, mmdet3d repo is already cloned and  packages required for mmdet3d and BEVFusion is installed.
You can test the docker by ruunning
'bash tools/dist_train.sh projects/BEVFusion/configs/bevfusion_lidar_voxel0075_second_secfpn_8xb4-cyclic-20e_nus-3d.py 1' inside the docker, and you can see the model structure printed. (there could be some pkl miss error, which is not important)